### PR TITLE
Feature/reuse request with multipart form data

### DIFF
--- a/Softeq.XToolkit.HttpClient/Network/HttpRequestScheduler.cs
+++ b/Softeq.XToolkit.HttpClient/Network/HttpRequestScheduler.cs
@@ -335,7 +335,6 @@ namespace Softeq.XToolkit.HttpClient.Network
                 var client = GetSimpleHttpClient();
 
                 using (task.Request)
-                using (task.Request.Content)
                 {
                     var serverResponse = await client.SendAsync(task.Request, HttpCompletionOption.ResponseContentRead,
                         new CancellationTokenSource(task.Timeout).Token).ConfigureAwait(false);

--- a/Softeq.XToolkit.HttpClient/Network/ModifiedHttpClient.cs
+++ b/Softeq.XToolkit.HttpClient/Network/ModifiedHttpClient.cs
@@ -56,9 +56,9 @@ namespace Softeq.XToolkit.HttpClient.Network
                 message.Content = new StringContent(request.Data ?? string.Empty);
                 message.Content.Headers.ContentType = new MediaTypeHeaderValue(request.ContentType);
             }
-            else if (request.FormDataContent != null)
+            else if (request.FormDataProvider != null)
             {
-                message.Content = request.FormDataContent;
+                message.Content = request.FormDataProvider.GetContent();
             }
 
             return _httpRequestsScheduler.ExecuteAsync(

--- a/Softeq.XToolkit.ProjectInfrastructure/Content/IHttpContentProvider.cs
+++ b/Softeq.XToolkit.ProjectInfrastructure/Content/IHttpContentProvider.cs
@@ -1,0 +1,12 @@
+// Developed for PAWS-HALO by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Net.Http;
+
+namespace Softeq.XToolkit.CrossCutting.Content
+{
+    public interface IHttpContentProvider
+    {
+        HttpContent GetContent();
+    }
+}

--- a/Softeq.XToolkit.ProjectInfrastructure/HttpRequest.cs
+++ b/Softeq.XToolkit.ProjectInfrastructure/HttpRequest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using Newtonsoft.Json;
+using Softeq.XToolkit.CrossCutting.Content;
 
 namespace Softeq.XToolkit.CrossCutting
 {
@@ -17,7 +18,7 @@ namespace Softeq.XToolkit.CrossCutting
         public Dictionary<HttpRequestHeader, object> Headers { get; }
         public HttpMethod Method { get; set; }
         public Uri Uri { get; set; }
-        public MultipartFormDataContent FormDataContent { get; set; }
+        public IHttpContentProvider FormDataProvider { get; set; }
 
         public HttpRequest()
         {
@@ -126,11 +127,11 @@ namespace Softeq.XToolkit.CrossCutting
             return WithData(JsonConvert.SerializeObject(data));
         }
 
-        public HttpRequest WithFormData(MultipartFormDataContent data)
+        public HttpRequest WithFormDataProvider(IHttpContentProvider httpContentProvider)
         {
             ContentType = FormDataContentType;
 
-            FormDataContent = data;
+            FormDataProvider = httpContentProvider;
 
             return this;
         }


### PR DESCRIPTION
### Description of Change ###

Replace FormDataContent with FormDataProvider, so FormDataContent could be recreated multiple times from the same request

### Issues Resolved ### 

- fixes exception when using MultipartFormDataContent connected to multiple disposing the same object

### API Changes ###

Added:
 -  interface IHttpContentProvider

Changed:
 - MultipartFormDataContent HttpRequest.FormDataProvider { get; set; } => IHttpContentProvider HttpRequest.FormDataProvider { get; set; }
 - HttpRequest HttpRequest.WithFormData(MultipartFormDataContent data) => HttpRequest HttpRequest.WithFormDataProvider(IHttpContentProvider httpContentProvider)

### Platforms Affected ### 

- Core (all platforms)

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)