### PR TITLE
Implement IHttpClientProvider for HttpClient customization

### DIFF
--- a/Softeq.XToolkit.DefaultAuthorization/SecuredHttpServiceGate.cs
+++ b/Softeq.XToolkit.DefaultAuthorization/SecuredHttpServiceGate.cs
@@ -18,13 +18,16 @@ namespace Softeq.XToolkit.DefaultAuthorization
         private ForegroundTaskDeferral<ExecutionStatus> _sessionRetrievalDeferral;
         private IHttpClient _client;
 
-        public SecuredHttpServiceGate(ISessionApiService sessionApiService, HttpServiceGateConfig httpConfig,
-            ISecuredTokenManager tokenManager)
+        public SecuredHttpServiceGate(
+            ISessionApiService sessionApiService, 
+            HttpServiceGateConfig httpConfig,
+            ISecuredTokenManager tokenManager,
+            IHttpClientProvider httpClientProvider)
         {
             _tokenManager = tokenManager;
             _sessionApiService = sessionApiService;
             _sessionRetrievalDeferral = new ForegroundTaskDeferral<ExecutionStatus>();
-            _client = new ModifiedHttpClient(new HttpRequestsScheduler(httpConfig));
+            _client = new ModifiedHttpClient(new HttpRequestsScheduler(httpClientProvider, httpConfig));
         }
 
         public async Task<HttpResponse> ExecuteApiCallAsync(HttpRequest request,

--- a/Softeq.XToolkit.HttpClient/HttpServiceGate.cs
+++ b/Softeq.XToolkit.HttpClient/HttpServiceGate.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Softeq.XToolkit.CrossCutting;
 using Softeq.XToolkit.CrossCutting.Exceptions;
 using Softeq.XToolkit.HttpClient.Abstract;
+using Softeq.XToolkit.HttpClient.Infrastructure;
 using Softeq.XToolkit.HttpClient.Network;
 
 namespace Softeq.XToolkit.HttpClient
@@ -12,9 +13,9 @@ namespace Softeq.XToolkit.HttpClient
     {
         private readonly ModifiedHttpClient _client;
 
-        public HttpServiceGate(HttpServiceGateConfig config)
+        public HttpServiceGate(HttpServiceGateConfig config, IHttpClientProvider httpClientProvider)
         {
-            var httpRequestsScheduler = new HttpRequestsScheduler(config);
+            var httpRequestsScheduler = new HttpRequestsScheduler(httpClientProvider, config);
 
             _client = new ModifiedHttpClient(httpRequestsScheduler);
         }

--- a/Softeq.XToolkit.HttpClient/Infrastructure/DefaultHttpClientProvider.cs
+++ b/Softeq.XToolkit.HttpClient/Infrastructure/DefaultHttpClientProvider.cs
@@ -1,22 +1,23 @@
 using System.Net.Http.Headers;
+using SystemHttpClient = System.Net.Http.HttpClient;
 
 namespace Softeq.XToolkit.HttpClient.Infrastructure
 {
     public class DefaultHttpClientProvider : IHttpClientProvider
     {
-        public System.Net.Http.HttpClient CreateHttpClient()
+        public SystemHttpClient CreateHttpClient()
         {
             var httpClient = DoCreateHttpClientInstance();
             DoConfigureHttpClientInstance(httpClient);
             return httpClient;
         }
 
-        protected virtual System.Net.Http.HttpClient DoCreateHttpClientInstance()
+        protected virtual SystemHttpClient DoCreateHttpClientInstance()
         {
-            return new System.Net.Http.HttpClient();
+            return new SystemHttpClient();
         }
 
-        protected virtual void DoConfigureHttpClientInstance(System.Net.Http.HttpClient httpClient)
+        protected virtual void DoConfigureHttpClientInstance(SystemHttpClient httpClient)
         {
             httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
         }

--- a/Softeq.XToolkit.HttpClient/Infrastructure/DefaultHttpClientProvider.cs
+++ b/Softeq.XToolkit.HttpClient/Infrastructure/DefaultHttpClientProvider.cs
@@ -1,0 +1,24 @@
+using System.Net.Http.Headers;
+
+namespace Softeq.XToolkit.HttpClient.Infrastructure
+{
+    public class DefaultHttpClientProvider : IHttpClientProvider
+    {
+        public System.Net.Http.HttpClient CreateHttpClient()
+        {
+            var httpClient = DoCreateHttpClientInstance();
+            DoConfigureHttpClientInstance(httpClient);
+            return httpClient;
+        }
+
+        protected virtual System.Net.Http.HttpClient DoCreateHttpClientInstance()
+        {
+            return new System.Net.Http.HttpClient();
+        }
+
+        protected virtual void DoConfigureHttpClientInstance(System.Net.Http.HttpClient httpClient)
+        {
+            httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+        }
+    }
+}

--- a/Softeq.XToolkit.HttpClient/Infrastructure/IHttpClientProvider.cs
+++ b/Softeq.XToolkit.HttpClient/Infrastructure/IHttpClientProvider.cs
@@ -1,0 +1,7 @@
+namespace Softeq.XToolkit.HttpClient.Infrastructure
+{
+    public interface IHttpClientProvider
+    {
+        System.Net.Http.HttpClient CreateHttpClient();
+    }
+}

--- a/Softeq.XToolkit.HttpClient/Network/HttpRequestScheduler.cs
+++ b/Softeq.XToolkit.HttpClient/Network/HttpRequestScheduler.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +31,8 @@ namespace Softeq.XToolkit.HttpClient.Network
         private readonly HttpRequestPriority _highestPriority;
         private readonly HttpServiceGateConfig _config;
 
+        private readonly IHttpClientProvider _httpClientProvider;
+
         private System.Net.Http.HttpClient _simpleHttpClient;
 
         private CancellationTokenSource _tasksExecutionCancellation;
@@ -40,8 +41,9 @@ namespace Softeq.XToolkit.HttpClient.Network
         private ConcurrentDictionary<Guid, HttpRequestScheduledTaskBase> _taskIdToTaskMap;
         private Dictionary<HttpRequestPriority, SimplePriorityQueue<HttpRequestScheduledTaskBase>> _perPriorityQueue;
 
-        public HttpRequestsScheduler(HttpServiceGateConfig config)
+        public HttpRequestsScheduler(IHttpClientProvider httpClientProvider, HttpServiceGateConfig config)
         {
+            _httpClientProvider = httpClientProvider;
             _config = config;
 
             _supportedStatusCodes = Enum.GetValues(typeof(HttpStatusCode)).Cast<int>().ToImmutableHashSet();
@@ -413,8 +415,7 @@ namespace Softeq.XToolkit.HttpClient.Network
         {
             if (_simpleHttpClient == null)
             {
-                _simpleHttpClient = new System.Net.Http.HttpClient();
-                _simpleHttpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+                _simpleHttpClient = _httpClientProvider.CreateHttpClient();
             }
 
             return _simpleHttpClient;


### PR DESCRIPTION
### Description

Added IHttpClientProvider to be able to customize HttpClient

### API Changes

Added:
 - interface IHttpClientProvider { HttpClient CreateHttpClient(); }
 - class DefaultHttpClientProvider : IHttpClientProvider - default implementation of IHttpClientProvider

### Platforms Affected

- Core (all platforms)
