### PR TITLE
error handling changed

### DIFF
--- a/Softeq.XToolkit.HttpClient/Network/HttpRequestScheduler.cs
+++ b/Softeq.XToolkit.HttpClient/Network/HttpRequestScheduler.cs
@@ -370,6 +370,9 @@ namespace Softeq.XToolkit.HttpClient.Network
             }
             catch (Exception ex)
             {
+                // KA: Android HttpClient throws native exception instread of TaskCanceledException(https://github.com/xamarin/xamarin-android/issues/3216).
+                // iOS works as expected. Right exception is thrown.
+                // To catch TimeoutException for both platforms cancellation token is checked.
                 task.Response = timeoutCancellationToken.IsCancellationRequested
                     ? new HttpResponse
                     {


### PR DESCRIPTION
On Halo.Droid HttpClient is implemented with **AndroidClientHandler**. According to [documentation](https://docs.microsoft.com/en-us/xamarin/android/app-fundamentals/http-stack?tabs=macos), when Timeout occurs nativeExceptions is thrown instead of TaskCanceledException. Halo.iOS throws exception as [expected](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.sendasync?view=net-6.0).  